### PR TITLE
Use Ember.String.htmlSafe to avoid warnings in Ember > 2.6.0

### DIFF
--- a/addon/helpers/i18n-n.js
+++ b/addon/helpers/i18n-n.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import gettext from 'ember-cli-gettext/gettext';
 
 export function getText(params, hash) {
-  return new Ember.Handlebars.SafeString(gettext._n(...params, hash));
+  return new Ember.String.htmlSafe(gettext._n(...params, hash));
 }
 
 export default Ember.Helper.helper(getText);

--- a/addon/helpers/i18n-t.js
+++ b/addon/helpers/i18n-t.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import gettext from 'ember-cli-gettext/gettext';
 
 export function getText(params, hash) {
-  return new Ember.Handlebars.SafeString(gettext._t(...params, hash));
+  return new Ember.String.htmlSafe(gettext._t(...params, hash));
 }
 
 export default Ember.Helper.helper(getText);


### PR DESCRIPTION
Updating the helpers to use `Ember.String.htmlSafe` since `Handlebars.SafeString` is deprecated and throws warnings.

😎



